### PR TITLE
Fix google oauth

### DIFF
--- a/backend/src/main/java/com/github/ramezch/backend/auth/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/github/ramezch/backend/auth/CustomOAuth2UserService.java
@@ -13,8 +13,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/github/ramezch/backend/auth/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/github/ramezch/backend/auth/CustomOAuth2UserService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
 
 @Service
 @RequiredArgsConstructor
@@ -38,8 +40,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String id;
         String username;
         String avatarUrl;
-
-        System.out.println(oAuth2User);
 
         if ("github".equals(provider)) {
             id = oAuth2User.getName();

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -5,5 +5,5 @@ spring.security.oauth2.client.registration.github.client-secret=${GITHUB_SECRET}
 spring.security.oauth2.client.registration.github.scope=none
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_SECRET_ID}
-spring.security.oauth2.client.registration.google.scope=openid, profile, email
+spring.security.oauth2.client.registration.google.scope=profile, email
 app.url=${APP_URL}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -5,5 +5,5 @@ spring.security.oauth2.client.registration.github.client-secret=${GITHUB_SECRET}
 spring.security.oauth2.client.registration.github.scope=none
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_SECRET_ID}
-spring.security.oauth2.client.registration.google.scope=openid, picture, email
+spring.security.oauth2.client.registration.google.scope=openid, profile, email
 app.url=${APP_URL}


### PR DESCRIPTION
Removed **openid** from the scope. Now, instead of relying on Spring Security to look for OIDC (OpenID Connect) when logging in with Google OAuth, the system is forced to use OAuth2.